### PR TITLE
fix incontrol x optifine issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation fg.deobf("curse.maven:firstaid-${firstaid_version}")
     implementation fg.deobf("curse.maven:foodexpansion-${foodexpansion_version}")
     implementation fg.deobf("curse.maven:forgottenitems-${forgottenitems_version}")
+    implementation fg.deobf("curse.maven:in-control-${incontrol_version}")
     implementation fg.deobf("curse.maven:infernalmobs-${infernalmobs_version}")
     implementation fg.deobf("curse.maven:inspirations-${inspirations_version}")
     implementation fg.deobf("curse.maven:itemphysics-${itemphysics_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,6 +62,7 @@ fancymenu_version=367706:4655936
 firstaid_version=276837:4414252
 foodexpansion_version=235328:2573308
 forgottenitems_version=262884:4167346
+incontrol_version=257356:3101719
 infernalmobs_version=227875:2771611
 inspirations_version=284007:2843007
 itemphysics_version=258587:3487676

--- a/src/main/java/fermiummixins/config/InControlConfig.java
+++ b/src/main/java/fermiummixins/config/InControlConfig.java
@@ -1,0 +1,28 @@
+package fermiummixins.config;
+
+import fermiumbooter.annotations.MixinConfig;
+import fermiummixins.FermiumMixins;
+import fermiummixins.util.ModLoadedUtil;
+import net.minecraftforge.common.config.Config;
+
+@MixinConfig(name = FermiumMixins.MODID)
+public class InControlConfig {
+
+    @Config.Comment("InControl can apply actions on entities when they spawn like changing their stats or giving them held items. OptiFine saves entities that attempt to spawn to not have to construct them again, for performance.\n" +
+            "This creates an interaction where InControl will often apply the same action multiple times on the same entity. \n" +
+            "This fix makes InControl spawn actions only apply once per entity.")
+    @Config.Name("Fix InControl spawn actions applied multiple times (InControl/OptiFine)")
+    @Config.RequiresMcRestart
+    @MixinConfig.MixinToggle(lateMixin = "mixins.fermiummixins.late.incontrol.spawnrulefix.json", defaultValue = false)
+    @MixinConfig.CompatHandling(
+            modid = ModLoadedUtil.InControl_MODID,
+            desired = true,
+            reason = "Requires mod to properly function"
+    )
+    @MixinConfig.CompatHandling(
+            modid = ModLoadedUtil.Optifine_MODID,
+            desired = true,
+            reason = "Issue only arises if OptiFine is present"
+    )
+    public boolean fixSpawnActionRepetitionWithOptiFine = false;
+}

--- a/src/main/java/fermiummixins/handlers/ConfigHandler.java
+++ b/src/main/java/fermiummixins/handlers/ConfigHandler.java
@@ -97,6 +97,9 @@ public class ConfigHandler {
 	
 	@Config.Name("ForgottenItems Config")
 	public static final ForgottenItemsConfig FORGOTTENITEMS_CONFIG = new ForgottenItemsConfig();
+
+	@Config.Name("InControl Config")
+	public static final InControlConfig INCONTROL_CONFIG = new InControlConfig();
 	
 	@Config.Name("InfernalMobs Config")
 	public static final InfernalMobsConfig INFERNALMOBS_CONFIG = new InfernalMobsConfig();

--- a/src/main/java/fermiummixins/handlers/vanilla/InControlOptiFineHandler.java
+++ b/src/main/java/fermiummixins/handlers/vanilla/InControlOptiFineHandler.java
@@ -1,0 +1,21 @@
+package fermiummixins.handlers.vanilla;
+
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.spongepowered.asm.mixin.Unique;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class InControlOptiFineHandler {
+    @Unique public static final Set<UUID> savedUUIDS = new HashSet<>();
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST, receiveCanceled = true)
+    public static void onSpecialSpawn(LivingSpawnEvent.SpecialSpawn event){
+        savedUUIDS.remove(event.getEntity().getUniqueID());
+        //Removing is just to keep the set of saved uuids as small as possible
+        //OptiFine removes its saved entities when CheckSpawn and the additional spawn placement checks succeed, right before firing SpecialSpawn.
+    }
+}

--- a/src/main/java/fermiummixins/mixin/incontrol/SpawnRuleMixin.java
+++ b/src/main/java/fermiummixins/mixin/incontrol/SpawnRuleMixin.java
@@ -1,0 +1,30 @@
+package fermiummixins.mixin.incontrol;
+
+import fermiummixins.handlers.vanilla.InControlOptiFineHandler;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import mcjty.incontrol.rules.SpawnRule;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.UUID;
+
+@Mixin(SpawnRule.class)
+public class SpawnRuleMixin {
+
+    @Inject(
+            method = "match(Lnet/minecraftforge/event/entity/living/LivingSpawnEvent$CheckSpawn;)Z",
+            at = @At("HEAD"),
+            remap = false,
+            cancellable = true
+    )
+    private void fermiumMixins_inControlSpawnRule_matchCheckSpawn(LivingSpawnEvent.CheckSpawn event, CallbackInfoReturnable<Boolean> cir){
+        UUID uuid = event.getEntity().getUniqueID();
+        if(InControlOptiFineHandler.savedUUIDS.contains(uuid)){
+            cir.setReturnValue(false); //Don't apply actions on mobs that already have had those actions applied
+            //Only needed when using OptiFine, as OptiFine caches constructed entities and reuses them for CheckSpawn until spawn the entity succeeds (risky fix by OptiFine but alright)
+        } else
+            InControlOptiFineHandler.savedUUIDS.add(uuid);
+    }
+}

--- a/src/main/java/fermiummixins/proxy/CommonProxy.java
+++ b/src/main/java/fermiummixins/proxy/CommonProxy.java
@@ -14,6 +14,7 @@ import fermiummixins.handlers.quark.ChestBoatDupeHandler;
 import fermiummixins.handlers.quark.RightClickSignEditHandler;
 import fermiummixins.handlers.reskillable.UndershirtHandler;
 import fermiummixins.handlers.spawnercontrol.SpawnerFarmingHandler;
+import fermiummixins.handlers.vanilla.InControlOptiFineHandler;
 import fermiummixins.handlers.vanilla.LightningItemDamageHandler;
 import fermiummixins.handlers.vanilla.TimeCacheHandler;
 import fermiummixins.util.ModLoadedUtil;
@@ -42,6 +43,9 @@ public class CommonProxy {
         }
         if(ConfigHandler.FORGOTTENITEMS_CONFIG.veinPickaxeAbusePatch && ModLoadedUtil.isForgottenItemsLoaded()) {
             MinecraftForge.EVENT_BUS.register(VeinPickaxeHandler.class);
+        }
+        if(ConfigHandler.INCONTROL_CONFIG.fixSpawnActionRepetitionWithOptiFine && ModLoadedUtil.isInControlLoaded() && ModLoadedUtil.isOptifineLoaded()) {
+            MinecraftForge.EVENT_BUS.register(InControlOptiFineHandler.class);
         }
         if(ConfigHandler.INSPIRATIONS_CONFIG.milkingCooldownFix && ModLoadedUtil.isInspirationsLoaded()) {
             MinecraftForge.EVENT_BUS.register(MilkCooldownHandler.class);

--- a/src/main/java/fermiummixins/util/ModLoadedUtil.java
+++ b/src/main/java/fermiummixins/util/ModLoadedUtil.java
@@ -37,6 +37,7 @@ public abstract class ModLoadedUtil {
 	public static final String FirstAid_MODID = "firstaid";
 	public static final String FoodExpansion_MODID = "foodexpansion";
 	public static final String ForgottenItems_MODID = "forgottenitems";
+	public static final String InControl_MODID = "incontrol";
 	public static final String InfernalMobs_MODID = "infernalmobs";
 	public static final String Inspirations_MODID = "inspirations";
 	public static final String ItemPhysics_MODID = "itemphysic";
@@ -75,6 +76,7 @@ public abstract class ModLoadedUtil {
 	private static Boolean charmLoaded = null;
 	private static Boolean firstAidLoaded = null;
 	private static Boolean forgottenItemsLoaded = null;
+	private static Boolean inControlLoaded = null;
 	private static Boolean infernalMobsLoaded = null;
 	private static Boolean inspirationsLoaded = null;
 	private static Boolean optifineLoaded = null;
@@ -118,6 +120,11 @@ public abstract class ModLoadedUtil {
 	public static boolean isForgottenItemsLoaded() {
 		if(forgottenItemsLoaded == null) forgottenItemsLoaded = Loader.isModLoaded(ForgottenItems_MODID);
 		return forgottenItemsLoaded;
+	}
+
+	public static boolean isInControlLoaded() {
+		if(inControlLoaded == null) inControlLoaded = Loader.isModLoaded(InControl_MODID);
+		return inControlLoaded;
 	}
 	
 	public static boolean isInfernalMobsLoaded() {

--- a/src/main/resources/mixins.fermiummixins.late.incontrol.spawnrulefix.json
+++ b/src/main/resources/mixins.fermiummixins.late.incontrol.spawnrulefix.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "fermiummixins.mixin",
+  "refmap": "mixins.fermiummixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "incontrol.SpawnRuleMixin"
+  ]
+}


### PR DESCRIPTION
incontrol can apply "actions" in their spawn rules like changing mob stats during checkspawn. optifine caches already constructed entities during the spawning logic until they actually succeed in spawning

this interacts with checkspawn being called multiple times on the same entity until it succeeds in spawning giving it way higher stats than it should have (or for example way higher chance than intended for held items etc)

this fix just saves uuids of mobs going through checkspawn and only applies incontrol actions on each entity once.

eagle already had an issue with this in dregora, cd now has a similar issue with custom spawn actions added in lycanitestweaks

incontrol itself/mcjtytools had a lazy fix for it which never got released and UniversalTweaks just copied that without actually fixing the issue
https://github.com/McJtyMods/McJtyTools/commit/9cd16506c1e3d5c22f1adb48bde22e562358f82b
https://github.com/ACGaming/UniversalTweaks/pull/557