### PR TITLE
switchbow null stack fix

### DIFF
--- a/src/main/java/fermiummixins/config/SwitchbowConfig.java
+++ b/src/main/java/fermiummixins/config/SwitchbowConfig.java
@@ -40,4 +40,15 @@ public class SwitchbowConfig {
 			reason = "Requires mod to properly function"
 	)
 	public boolean luckArrowLootingFix = false;
+
+	@Config.Comment("Fixes Arrow Dispenser Blocks shooting using a fake entity that returns null ItemStacks when queried for held items (e.g. bow).")
+	@Config.Name("Null Stack Fix (Switchbow)")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(lateMixin = "mixins.fermiummixins.late.switchbow.arrowlaunchernullstacks.json", defaultValue = false)
+	@MixinConfig.CompatHandling(
+			modid = ModLoadedUtil.Switchbow_MODID,
+			desired = true,
+			reason = "Requires mod to properly function"
+	)
+	public boolean arrowLauncherNullStacks = false;
 }

--- a/src/main/java/fermiummixins/mixin/switchbow/EntityArrowLauncherMixin.java
+++ b/src/main/java/fermiummixins/mixin/switchbow/EntityArrowLauncherMixin.java
@@ -1,0 +1,30 @@
+package fermiummixins.mixin.switchbow;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import de.Whitedraco.switchbow.entity.EntityArrowLauncher;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHandSide;
+import net.minecraft.util.NonNullList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(EntityArrowLauncher.class)
+public class EntityArrowLauncherMixin {
+    @ModifyReturnValue(method = "getArmorInventoryList", at = @At("RETURN"))
+    private Iterable<ItemStack> fermiumMixins_switchBowEntityArrowLauncher_getArmorInventoryList(Iterable<ItemStack> original){
+        if(original != null) return original;
+        return NonNullList.withSize(4, ItemStack.EMPTY); //could return an empty list but if any mod assumes it's 4 entries, i'd rather have it be 4 entries
+    }
+
+    @ModifyReturnValue(method = "getItemStackFromSlot", at = @At("RETURN"))
+    private ItemStack fermiumMixins_switchBowEntityArrowLauncher_getItemStackFromSlot(ItemStack original){
+        if(original != null) return original;
+        return ItemStack.EMPTY;
+    }
+
+    @ModifyReturnValue(method = "getPrimaryHand", at = @At("RETURN"))
+    private EnumHandSide fermiumMixins_switchBowEntityArrowLauncher_getPrimaryHand(EnumHandSide original){
+        if(original != null) return original;
+        return EnumHandSide.RIGHT;
+    }
+}

--- a/src/main/resources/mixins.fermiummixins.late.switchbow.arrowlaunchernullstacks.json
+++ b/src/main/resources/mixins.fermiummixins.late.switchbow.arrowlaunchernullstacks.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "fermiummixins.mixin",
+  "refmap": "mixins.fermiummixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "switchbow.EntityArrowLauncherMixin"
+  ]
+}


### PR DESCRIPTION
arrow dispenser blocks use a fake entity to shoot the arrows which returns null stacks for held items. this makes it return empty stacks instead.