### PR TITLE
fixed fast bolts + arrow velocity clamp

### DIFF
--- a/src/main/java/fermiummixins/config/VanillaConfig.java
+++ b/src/main/java/fermiummixins/config/VanillaConfig.java
@@ -528,6 +528,12 @@ public class VanillaConfig {
 	@Config.RequiresMcRestart
 	@MixinConfig.MixinToggle(earlyMixin = "mixins.fermiummixins.early.vanilla.blockstorageoptifine.json", defaultValue = false)
 	public boolean blockStorageOptifineLagFix = false;
+
+	@Config.Comment("Fixes Vanilla limiting individual velocity vector components (X and Z) to values between -3.9 and +3.9 (blocks per tick) when sending entity velocity update packets to clients, making fast projectiles visibly strafe sideways when shot in specific directions.")
+	@Config.Name("Entity Velocity Sync (Vanilla)")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(earlyMixin = "mixins.fermiummixins.early.vanilla.entityvelocitysync.json", defaultValue = false)
+	public boolean entityVelocitySync = false;
 	
 	private Set<Potion> tippedArrowBlacklistedPotions = null;
 	private List<String> particleRetainCollisionClasses = null;

--- a/src/main/java/fermiummixins/mixin/vanilla/SPacketEntityVelocityMixin.java
+++ b/src/main/java/fermiummixins/mixin/vanilla/SPacketEntityVelocityMixin.java
@@ -1,0 +1,26 @@
+package fermiummixins.mixin.vanilla;
+
+import net.minecraft.network.play.server.SPacketEntityVelocity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(SPacketEntityVelocity.class)
+public abstract class SPacketEntityVelocityMixin {
+    // see https://youtu.be/Q_MkxSD33Vw?si=uDKlxttiKw21lXuW&t=1335
+    @ModifyConstant(
+            method = "<init>(IDDD)V",
+            constant = @Constant(doubleValue = -3.9D)
+    )
+    private double fermiumMixins_vanillaSPacketEntityVelocity_init_negLimit(double constant){
+        return -Double.MAX_VALUE;
+    }
+
+    @ModifyConstant(
+            method = "<init>(IDDD)V",
+            constant = @Constant(doubleValue = 3.9D)
+    )
+    private double fermiumMixins_vanillaSPacketEntityVelocity_init_posLimit(double constant){
+        return Double.MAX_VALUE;
+    }
+}

--- a/src/main/resources/mixins.fermiummixins.early.vanilla.entityvelocitysync.json
+++ b/src/main/resources/mixins.fermiummixins.early.vanilla.entityvelocitysync.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "fermiummixins.mixin",
+  "refmap": "mixins.fermiummixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "vanilla.SPacketEntityVelocityMixin"
+  ]
+}


### PR DESCRIPTION
bolts and arrows shot at high speed can seem to go in very weird directions due to vanilla clamping individual vector components when sending entity velocities to the client.

this is a bug found in 1.21.5 (presented by cubicmetre in https://youtu.be/Q_MkxSD33Vw?si=uDKlxttiKw21lXuW&t=1335 ) but its present in 1.12.2 too