### PR TITLE
Lycanites Transforming Ticks Spawner Control

### DIFF
--- a/src/main/java/fermiummixins/config/SpawnerControlConfig.java
+++ b/src/main/java/fermiummixins/config/SpawnerControlConfig.java
@@ -18,6 +18,22 @@ public class SpawnerControlConfig {
 			reason = "Requires mod to properly function"
 	)
 	public boolean curingTicksSpawners = false;
+
+	@Config.Comment("Makes Lycanites entities that transform into new entities (fusion and others) count as a kill for spawners")
+	@Config.Name("Lycanites Transforming Ticks Spawners (MobSpawnerControl/LycanitesMobs)")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(lateMixin = "mixins.fermiummixins.late.spawnercontrol.lycanitesmobs.json", defaultValue = false)
+	@MixinConfig.CompatHandling(
+			modid = ModLoadedUtil.SpawnerControl_MODID,
+			desired = true,
+			reason = "Requires mod to properly function"
+	)
+	@MixinConfig.CompatHandling(
+			modid = ModLoadedUtil.LycanitesMobs_MODID,
+			desired = true,
+			reason = "Requires mod to properly function"
+	)
+	public boolean lycanitesTicksSpawners = false;
 	
 	@Config.Comment("After a spawner is broken, prevents mob drops after a certain threshold of kills is reached to prevent farming exploits")
 	@Config.Name("Spawner Farming Fix (MobSpawnerControl)")
@@ -34,20 +50,4 @@ public class SpawnerControlConfig {
 			"Requires \"Spawner Farming Fix (MobSpawnerControl)\" enabled")
 	@Config.Name("Spawner Farming Fix Threshold")
 	public int spawnerFarmingFixThreshold = 20;
-
-	@Config.Comment("Makes Lycanites entities that transform into new entities count as a kill for spawners")
-	@Config.Name("Lycanites Transforming Ticks Spawners (MobSpawnerControl/LycanitesMobs)")
-	@Config.RequiresMcRestart
-	@MixinConfig.MixinToggle(lateMixin = "mixins.fermiummixins.late.spawnercontrol.lycanitesmobs.json", defaultValue = false)
-	@MixinConfig.CompatHandling(
-			modid = ModLoadedUtil.SpawnerControl_MODID,
-			desired = true,
-			reason = "Requires mod to properly function"
-	)
-	@MixinConfig.CompatHandling(
-			modid = ModLoadedUtil.LycanitesMobs_MODID,
-			desired = true,
-			reason = "Requires mod to properly function"
-	)
-	public boolean lycanitesTicksSpawners = false;
 }

--- a/src/main/java/fermiummixins/config/SpawnerControlConfig.java
+++ b/src/main/java/fermiummixins/config/SpawnerControlConfig.java
@@ -34,4 +34,20 @@ public class SpawnerControlConfig {
 			"Requires \"Spawner Farming Fix (MobSpawnerControl)\" enabled")
 	@Config.Name("Spawner Farming Fix Threshold")
 	public int spawnerFarmingFixThreshold = 20;
+
+	@Config.Comment("Makes Lycanites entities that transform into new entities count as a kill for spawners")
+	@Config.Name("Lycanites Transforming Ticks Spawners (MobSpawnerControl/LycanitesMobs)")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(lateMixin = "mixins.fermiummixins.late.spawnercontrol.lycanitesmobs.json", defaultValue = false)
+	@MixinConfig.CompatHandling(
+			modid = ModLoadedUtil.SpawnerControl_MODID,
+			desired = true,
+			reason = "Requires mod to properly function"
+	)
+	@MixinConfig.CompatHandling(
+			modid = ModLoadedUtil.LycanitesMobs_MODID,
+			desired = true,
+			reason = "Requires mod to properly function"
+	)
+	public boolean lycanitesTicksSpawners = false;
 }

--- a/src/main/java/fermiummixins/mixin/spawnercontrol/lycanitesmobs/BaseCreatureEntity_TransformMixin.java
+++ b/src/main/java/fermiummixins/mixin/spawnercontrol/lycanitesmobs/BaseCreatureEntity_TransformMixin.java
@@ -3,7 +3,6 @@ package fermiummixins.mixin.spawnercontrol.lycanitesmobs;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.lycanitesmobs.core.entity.BaseCreatureEntity;
-import fermiummixins.util.ModLoadedUtil;
 import fermiummixins.wrapper.SpawnerControlWrapper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
@@ -24,7 +23,7 @@ public abstract class BaseCreatureEntity_TransformMixin extends EntityLiving {
             remap = false
     )
     private boolean fermiummixins_lycanitesMobsBaseCreatureEntity_transform(World instance, Entity resultingEntity, @Local(argsOnly = true) Entity partner, @Local(argsOnly = true) boolean destroyPartner) {
-        if(!this.world.isRemote && ModLoadedUtil.isSpawnerControlLoaded()) {
+        if(!this.world.isRemote) {
             SpawnerControlWrapper.increaseSpawnerCount(this); // Increase for initiating fusion entity
             if(destroyPartner) {
                 SpawnerControlWrapper.increaseSpawnerCount(partner); // Increase for target fusion partner

--- a/src/main/java/fermiummixins/mixin/spawnercontrol/lycanitesmobs/BaseCreatureEntity_TransformMixin.java
+++ b/src/main/java/fermiummixins/mixin/spawnercontrol/lycanitesmobs/BaseCreatureEntity_TransformMixin.java
@@ -1,0 +1,37 @@
+package fermiummixins.mixin.spawnercontrol.lycanitesmobs;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.lycanitesmobs.core.entity.BaseCreatureEntity;
+import fermiummixins.util.ModLoadedUtil;
+import fermiummixins.wrapper.SpawnerControlWrapper;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(BaseCreatureEntity.class)
+public abstract class BaseCreatureEntity_TransformMixin extends EntityLiving {
+
+    public BaseCreatureEntity_TransformMixin(World world) {
+        super(world);
+    }
+
+    @WrapWithCondition(
+            method = "transform",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z", remap = true),
+            remap = false
+    )
+    private boolean fermiummixins_lycanitesMobsBaseCreatureEntity_transform(World instance, Entity resultingEntity, @Local(argsOnly = true) Entity partner, @Local(argsOnly = true) boolean destroyPartner) {
+        if(!this.world.isRemote && ModLoadedUtil.isSpawnerControlLoaded()) {
+            SpawnerControlWrapper.increaseSpawnerCount(this); // Increase for initiating fusion entity
+            if(destroyPartner) {
+                SpawnerControlWrapper.increaseSpawnerCount(partner); // Increase for target fusion partner
+            }
+            // Cancel spawning resulting Entity
+            return !SpawnerControlWrapper.shouldCancelDrops(this) && !SpawnerControlWrapper.shouldCancelDrops(partner);
+        }
+        return true;
+    }
+}

--- a/src/main/java/fermiummixins/mixin/spawnercontrol/vanilla/EntityPig_CuringMixin.java
+++ b/src/main/java/fermiummixins/mixin/spawnercontrol/vanilla/EntityPig_CuringMixin.java
@@ -1,7 +1,6 @@
 package fermiummixins.mixin.spawnercontrol.vanilla;
 
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
-import fermiummixins.util.ModLoadedUtil;
 import fermiummixins.wrapper.SpawnerControlWrapper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.EntityAnimal;
@@ -22,10 +21,7 @@ public abstract class EntityPig_CuringMixin extends EntityAnimal {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z")
     )
     private boolean fermiummixins_vanillaEntityPig_onStruckByLightning(World instance, Entity entity) {
-        if(ModLoadedUtil.isSpawnerControlLoaded()) {
-            SpawnerControlWrapper.increaseSpawnerCount(this);
-			return !SpawnerControlWrapper.shouldCancelDrops(this);
-        }
-        return true;
+        SpawnerControlWrapper.increaseSpawnerCount(this);
+        return !SpawnerControlWrapper.shouldCancelDrops(this);
     }
 }

--- a/src/main/java/fermiummixins/mixin/spawnercontrol/vanilla/EntityZombieVillager_CuringMixin.java
+++ b/src/main/java/fermiummixins/mixin/spawnercontrol/vanilla/EntityZombieVillager_CuringMixin.java
@@ -1,6 +1,5 @@
 package fermiummixins.mixin.spawnercontrol.vanilla;
 
-import fermiummixins.util.ModLoadedUtil;
 import fermiummixins.wrapper.SpawnerControlWrapper;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.monster.EntityZombieVillager;
@@ -23,7 +22,7 @@ public abstract class EntityZombieVillager_CuringMixin extends EntityZombie {
             cancellable = true
     )
     private void fermiummixins_vanillaEntityZombieVillager_finishConversion(CallbackInfo ci) {
-        if(!this.world.isRemote && ModLoadedUtil.isSpawnerControlLoaded()) {
+        if(!this.world.isRemote) {
             SpawnerControlWrapper.increaseSpawnerCount(this);
             if(SpawnerControlWrapper.shouldCancelDrops(this)) {
                 this.setDead();

--- a/src/main/resources/mixins.fermiummixins.late.spawnercontrol.lycanitesmobs.json
+++ b/src/main/resources/mixins.fermiummixins.late.spawnercontrol.lycanitesmobs.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "fermiummixins.mixin",
+  "refmap": "mixins.fermiummixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "spawnercontrol.lycanitesmobs.BaseCreatureEntity_TransformMixin"
+  ]
+}


### PR DESCRIPTION
I was notified by Nischhelm that a common Lycanites spawner was exploitable. It was as simple as creating fusion to convert the entire room.

This applies the pig and zombie curing to Lycanites transformation, checks both solo and partner transformations.

I considered allowing the entity to be spawned but use lycanites handling to cancel drops, but decided to keep it consistent.