### PR TITLE
Remove bauble shield copied shield handling via onLivingAttack

### DIFF
--- a/src/main/java/fermiummixins/mixin/bountifulbaubles/ItemShieldCobalt_ShieldMixin.java
+++ b/src/main/java/fermiummixins/mixin/bountifulbaubles/ItemShieldCobalt_ShieldMixin.java
@@ -5,7 +5,13 @@ import cursedflames.bountifulbaubles.item.ModItems;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemShield;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.living.LivingAttackEvent;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import javax.annotation.Nullable;
 
@@ -15,5 +21,23 @@ public abstract class ItemShieldCobalt_ShieldMixin extends ItemShield {
     @Override
     public boolean isShield(ItemStack stack, @Nullable EntityLivingBase entity) {
         return stack.getItem() == ModItems.shieldCobalt;
+    }
+
+    // Remove jank copy of shield handling
+    @Inject(
+            method = "onLivingAttack",
+            at = @At("HEAD"),
+            cancellable = true,
+            remap = false
+    )
+    private static void fermiummixins_bountifulBaublesItemShieldCobalt_onLivingAttack(LivingAttackEvent event, CallbackInfo ci){
+        ci.cancel();
+    }
+
+    // Unbreakable-unusable intention
+    @Unique
+    @Override
+    public void setDamage(@NotNull ItemStack stack, int damage){
+        super.setDamage(stack, Math.min(damage, this.getMaxDamage(stack)));
     }
 }


### PR DESCRIPTION
Better version of the disaster from my previous https://github.com/FermiumModding/RLMixins/pull/35

Removes the modified copy of vanilla shield handling onLivingAttack, which caused increased durability damage that could rapidly destroy the shield from an attack that was active every tick.

Restores the intended 0 durability unusable state as it was intended to never be breakable like an Elytra.