### PR TITLE
Improve block state registry patch

### DIFF
--- a/src/main/java/fermiummixins/mixin/vanilla/BlockStateBase_IdentityMixin.java
+++ b/src/main/java/fermiummixins/mixin/vanilla/BlockStateBase_IdentityMixin.java
@@ -1,7 +1,6 @@
 package fermiummixins.mixin.vanilla;
 
 import fermiummixins.wrapper.IBlockStateIdentity;
-import fermiummixins.wrapper.BlockStateIdentityPatchWrapper;
 import net.minecraft.block.state.BlockStateBase;
 import net.minecraft.block.state.IBlockState;
 import org.spongepowered.asm.mixin.Mixin;
@@ -10,9 +9,14 @@ import org.spongepowered.asm.mixin.Unique;
 @Mixin(BlockStateBase.class)
 public abstract class BlockStateBase_IdentityMixin implements IBlockState, IBlockStateIdentity {
 	
-	//Registry is reference based, so each init is a new id
+	//ID for unknown state is -1
 	@Unique
-	private int fermiummixins$blockStateID = BlockStateIdentityPatchWrapper.getNewID();
+	private int fermiummixins$blockStateID = -1;
+	
+	@Override
+	public void fermiummixins$setIdentityKey(int id) {
+		this.fermiummixins$blockStateID = id;
+	}
 	
 	@Override
 	public int fermiummixins$getIdentityKey() {

--- a/src/main/java/fermiummixins/wrapper/IBlockStateIdentity.java
+++ b/src/main/java/fermiummixins/wrapper/IBlockStateIdentity.java
@@ -5,6 +5,8 @@ import org.apache.logging.log4j.Level;
 
 public interface IBlockStateIdentity {
 	
+	void fermiummixins$setIdentityKey(int id);
+	
 	default int fermiummixins$getIdentityKey() {
 		FermiumMixins.LOGGER.log(Level.ERROR, "FermiumMixins BlockState Identity Registry Patch has encountered unexpected behavior, disable this patch.");
 		return 0;


### PR DESCRIPTION
This PR makes a few changes to the block state registry identity patch.

Initial size of 65k does not have any significant benefit. At most you are going to save a few milliseconds of startup time. Better use a conservative initial capacity to avoid potential issues.

Store block state IDs in block state instances directly. Improves performance by avoiding two array list accesses and auto-unboxing.